### PR TITLE
Update ansi_term.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ regex = { version = "^0.2.1", optional = true }
 lazy_static =  { version = "0.2", optional = true}
 
 [dev-dependencies]
-ansi_term = "0.7"
+ansi_term = "0.11"
 
 [features]
 default = []


### PR DESCRIPTION
This just brings this (test-only) dependency up to date.