### PR TITLE
Trailing cells in right and center alignment mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub struct TabWriter<W> {
 }
 
 /// `Alignment` represents how a `TabWriter` should align text within its cell.
-#[derive(Debug,PartialEq,Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Alignment {
     /// Text should be aligned with the left edge of the cell
     Left,
@@ -260,7 +260,7 @@ impl<W: io::Write> io::Write for TabWriter<W> {
         let widths = cell_widths(
             &self.lines,
             self.minwidth,
-            self.alignment != Alignment::Left
+            self.alignment != Alignment::Left,
         );
 
         // This is a trick to avoid allocating padding for every cell.
@@ -362,7 +362,7 @@ impl<W: ::std::any::Any> error::Error for IntoInnerError<W> {
 fn cell_widths(
     lines: &Vec<Vec<Cell>>,
     minwidth: usize,
-    trailing_cell: bool
+    trailing_cell: bool,
 ) -> Vec<Vec<usize>> {
     // Naively, this algorithm looks like it could be O(n^2m) where `n` is
     // the number of lines and `m` is the number of contiguous columns.
@@ -382,12 +382,12 @@ fn cell_widths(
                 if trailing_cell {
                     if col >= line.len() {
                         // does not ignore last column
-                        break
+                        break;
                     }
                 } else {
                     if col + 1 >= line.len() {
                         // ignores last column
-                        break
+                        break;
                     }
                 }
                 contig_count += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub struct TabWriter<W> {
 }
 
 /// `Alignment` represents how a `TabWriter` should align text within its cell.
-#[derive(Debug)]
+#[derive(Debug,PartialEq,Eq)]
 pub enum Alignment {
     /// Text should be aligned with the left edge of the cell
     Left,
@@ -257,7 +257,11 @@ impl<W: io::Write> io::Write for TabWriter<W> {
         if self.curcell.size > 0 {
             self.term_curcell();
         }
-        let widths = cell_widths(&self.lines, self.minwidth);
+        let widths = cell_widths(
+            &self.lines,
+            self.minwidth,
+            self.alignment != Alignment::Left
+        );
 
         // This is a trick to avoid allocating padding for every cell.
         // Just allocate the most we'll ever need and borrow from it.
@@ -280,7 +284,7 @@ impl<W: io::Write> io::Write for TabWriter<W> {
                 let bytes =
                     &self.buf.get_ref()[cell.start..cell.start + cell.size];
                 if i >= widths.len() {
-                    // There is no width for the last column
+                    // There may be no width for the last column
                     assert_eq!(i, line.len() - 1);
                     self.w.write_all(bytes)?;
                 } else {
@@ -295,9 +299,15 @@ impl<W: io::Write> io::Write for TabWriter<W> {
                         }
                     };
                     right_spaces += self.padding;
-                    write!(&mut self.w, "{}", &padding[0..left_spaces])?;
+                    // Omit initial padding if this is the last cell and its empty
+                    if !(bytes.len() == 0 && i + 1 == line.len()) {
+                        write!(&mut self.w, "{}", &padding[0..left_spaces])?;
+                    }
                     self.w.write_all(bytes)?;
-                    write!(&mut self.w, "{}", &padding[0..right_spaces])?;
+                    // Omit final padding if this is the last cell.
+                    if i + 1 < line.len() {
+                        write!(&mut self.w, "{}", &padding[0..right_spaces])?;
+                    }
                 }
             }
         }
@@ -347,7 +357,13 @@ impl<W: ::std::any::Any> error::Error for IntoInnerError<W> {
     }
 }
 
-fn cell_widths(lines: &Vec<Vec<Cell>>, minwidth: usize) -> Vec<Vec<usize>> {
+/// Compute the widths of all cells.
+/// If `trailing_cell` is set, then a cell is placed to the right of the final tab on each line.
+fn cell_widths(
+    lines: &Vec<Vec<Cell>>,
+    minwidth: usize,
+    trailing_cell: bool
+) -> Vec<Vec<usize>> {
     // Naively, this algorithm looks like it could be O(n^2m) where `n` is
     // the number of lines and `m` is the number of contiguous columns.
     //
@@ -358,13 +374,21 @@ fn cell_widths(lines: &Vec<Vec<Cell>>, minwidth: usize) -> Vec<Vec<usize>> {
         if iline.is_empty() {
             continue;
         }
-        for col in ws[i].len()..(iline.len() - 1) {
+        let n_cols = iline.len() - 1 + trailing_cell as usize;
+        for col in ws[i].len()..n_cols {
             let mut width = minwidth;
             let mut contig_count = 0;
             for line in lines[i..].iter() {
-                if col + 1 >= line.len() {
-                    // ignores last column
-                    break;
+                if trailing_cell {
+                    if col >= line.len() {
+                        // does not ignore last column
+                        break
+                    }
+                } else {
+                    if col + 1 >= line.len() {
+                        // ignores last column
+                        break
+                    }
                 }
                 contig_count += 1;
                 width = cmp::max(width, line[col].width);

--- a/src/test.rs
+++ b/src/test.rs
@@ -91,16 +91,20 @@ fn test_one_cell() {
 
 #[test]
 fn test_one_tab_right() {
-    iseq(tabw().padding(2).minwidth(2).alignment(Alignment::Right),
-         "a\tb\nxx\tyy",
-         " a   b\nxx  yy");
+    iseq(
+        tabw().padding(2).minwidth(2).alignment(Alignment::Right),
+        "a\tb\nxx\tyy",
+        " a   b\nxx  yy",
+    );
 }
 
 #[test]
 fn test_one_tab_center() {
-    iseq(tabw().padding(2).minwidth(2).alignment(Alignment::Center),
-         "a\tb\nxx\tyy",
-         "a   b\nxx  yy");
+    iseq(
+        tabw().padding(2).minwidth(2).alignment(Alignment::Center),
+        "a\tb\nxx\tyy",
+        "a   b\nxx  yy",
+    );
 }
 
 #[test]
@@ -156,13 +160,19 @@ fn test_contiguous_columns_right() {
             "x\tfoo\tx\n",
             "x\tfoofoo\tx\n",
             "\n",
-            "x\tfoofoofoo\tx",
+            "x\tfoofoofoo\tx\n",
+            "\n",
+            "x\tfoo\tx\n",
+            "x\tfoofoo\tx\n",
         ),
         concat!(
             "x    foo x\n",
             "x foofoo x\n",
             "\n",
-            "x foofoofoo x",
+            "x foofoofoo x\n",
+            "\n",
+            "x    foo x\n",
+            "x foofoo x\n",
         ),
     )
 }
@@ -175,13 +185,19 @@ fn test_empty_cell_right() {
             "x\tfoo\tx\n",
             "x\tfoofoo\tx\n",
             "\t\n",
-            "x\tfoofoofoo\tx",
+            "x\tfoofoofoo\tx\n",
+            "\t\n",
+            "x\tfoo\tx\n",
+            "x\tfoofoo\tx\n",
         ),
         concat!(
             "x       foo x\n",
             "x    foofoo x\n",
             "  \n",
-            "x foofoofoo x",
+            "x foofoofoo x\n",
+            "  \n",
+            "x       foo x\n",
+            "x    foofoo x\n",
         ),
     )
 }
@@ -194,13 +210,19 @@ fn test_contiguous_columns_center() {
             "x\tfoo\txyx\n",
             "x\tfoofoo\tx\n",
             "\n",
-            "x\tfoofoofoo\tx",
+            "x\tfoofoofoo\tx\n",
+            "\n",
+            "x\tfoo\txyx\n",
+            "x\tfoofoo\tx\n",
         ),
         concat!(
             "x  foo   xyx\n",
             "x foofoo  x\n",
             "\n",
-            "x foofoofoo x",
+            "x foofoofoo x\n",
+            "\n",
+            "x  foo   xyx\n",
+            "x foofoo  x\n",
         ),
     )
 }
@@ -246,7 +268,8 @@ fn foobar() {
 #[test]
 #[cfg(feature = "ansi_formatting")]
 fn test_ansi_formatting() {
-    let output = "foo\tbar\tfoobar\n\
+    let output =
+        "foo\tbar\tfoobar\n\
          \x1b[31mföÅ\x1b[0m\t\x1b[32mbär\x1b[0m\t\x1b[36mfoobar\x1b[0m\n\
          \x1b[34mfoo\tbar\tfoobar\n\x1b[0m";
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -90,21 +90,17 @@ fn test_one_cell() {
 }
 
 #[test]
-fn test_one_cell_right() {
-    iseq(
-        tabw().padding(2).minwidth(2).alignment(Alignment::Right),
-        "a\tb\nxx\tyy",
-        " a  b\nxx  yy",
-    );
+fn test_one_tab_right() {
+    iseq(tabw().padding(2).minwidth(2).alignment(Alignment::Right),
+         "a\tb\nxx\tyy",
+         " a   b\nxx  yy");
 }
 
 #[test]
-fn test_one_cell_center() {
-    iseq(
-        tabw().padding(2).minwidth(2).alignment(Alignment::Center),
-        "a\tb\nxx\tyy",
-        "a   b\nxx  yy",
-    );
+fn test_one_tab_center() {
+    iseq(tabw().padding(2).minwidth(2).alignment(Alignment::Center),
+         "a\tb\nxx\tyy",
+         "a   b\nxx  yy");
 }
 
 #[test]
@@ -156,18 +152,57 @@ fn test_table_center() {
 fn test_contiguous_columns_right() {
     iseq(
         tabw().padding(1).minwidth(0).alignment(Alignment::Right),
-        "x\tfoo\tx\nx\tfoofoo\tx\n\nx\tfoofoofoo\tx",
-        "x    foo x\nx foofoo x\n\nx foofoofoo x",
-    );
+        concat!(
+            "x\tfoo\tx\n",
+            "x\tfoofoo\tx\n",
+            "\n",
+            "x\tfoofoofoo\tx",
+        ),
+        concat!(
+            "x    foo x\n",
+            "x foofoo x\n",
+            "\n",
+            "x foofoofoo x",
+        ),
+    )
+}
+
+#[test]
+fn test_empty_cell_right() {
+    iseq(
+        tabw().padding(1).minwidth(0).alignment(Alignment::Right),
+        concat!(
+            "x\tfoo\tx\n",
+            "x\tfoofoo\tx\n",
+            "\t\n",
+            "x\tfoofoofoo\tx",
+        ),
+        concat!(
+            "x       foo x\n",
+            "x    foofoo x\n",
+            "  \n",
+            "x foofoofoo x",
+        ),
+    )
 }
 
 #[test]
 fn test_contiguous_columns_center() {
     iseq(
         tabw().padding(1).minwidth(0).alignment(Alignment::Center),
-        "x\tfoo\tx\nx\tfoofoo\tx\n\nx\tfoofoofoo\tx",
-        "x  foo   x\nx foofoo x\n\nx foofoofoo x",
-    );
+        concat!(
+            "x\tfoo\txyx\n",
+            "x\tfoofoo\tx\n",
+            "\n",
+            "x\tfoofoofoo\tx",
+        ),
+        concat!(
+            "x  foo   xyx\n",
+            "x foofoo  x\n",
+            "\n",
+            "x foofoofoo x",
+        ),
+    )
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -268,8 +268,7 @@ fn foobar() {
 #[test]
 #[cfg(feature = "ansi_formatting")]
 fn test_ansi_formatting() {
-    let output =
-        "foo\tbar\tfoobar\n\
+    let output = "foo\tbar\tfoobar\n\
          \x1b[31mföÅ\x1b[0m\t\x1b[32mbär\x1b[0m\t\x1b[36mfoobar\x1b[0m\n\
          \x1b[34mfoo\tbar\tfoobar\n\x1b[0m";
 


### PR DESCRIPTION
Previously, a **cell** was a block of text to the left of some tab.

This meant that a table like this:

    aa\tbb
    a\tb

would be formatted as

    aa bb
     a b

in right-alignment mode because the b's were not actually in a cell, and
thus didn't get aligned.

This commit modifies the notion of a "cell" in right- and
center-alignment mode to also include text to the right of the last tab
on the line.

This text is now considered part of a cell and aligned accordingly.

Implemented as describe above, this change would cause many trailing
spaces to be printed in right- and center-alignment modes, including on
empty lines.

To alleviate this, trailing spaces in the final cell of a line are not
printed.

fixes #29