### PR TITLE
api: add TabWriter::ansi option and drop regex crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,11 @@ repository = "https://github.com/BurntSushi/tabwriter"
 readme = "README.md"
 keywords = ["tabs", "elastic", "aligned", "whitespace", "table"]
 license = "Unlicense/MIT"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-unicode-width = "0.1"
-lazy_static =  { version = "1", optional = true}
-
-[dependencies.regex]
-version = "1.3"
-optional = true
-default-features = false
-features = ["std"]
+unicode-width = "0.1.10"
 
 [features]
 default = []
-ansi_formatting = ["regex", "lazy_static"]
+ansi_formatting = []

--- a/README.md
+++ b/README.md
@@ -87,13 +87,16 @@ tabwriter = "1"
 
 ### Dealing with ANSI escape codes
 
-If you want `tabwriter` to be aware of ANSI escape codes, then compile it with
-the `ansi_formatting` feature enabled.
+If you want `tabwriter` to be aware of ANSI escape codes, then you should
+enable the `TabWriter::ansi` option. Previously this was done by enabling the
+crate feature `ansi_formatting`, but that feature is now deprecated. (If you
+use it, then `TabWriter::ansi` will be automatically enabled for you. Otherwise
+it is disabled by default.)
 
 
 ### Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.34.0`.
+This crate's minimum supported `rustc` version is `1.67.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires

--- a/src/test.rs
+++ b/src/test.rs
@@ -208,15 +208,34 @@ fn foobar() {
     );
 }
 
+// This tests that ANSI formatting is handled automatically when the ansi_formatting
+// feature is enabled without any other configuration.
 #[test]
 #[cfg(feature = "ansi_formatting")]
-fn test_ansi_formatting() {
+fn ansi_formatting_by_feature() {
     let output = "foo\tbar\tfoobar\n\
          \x1b[31mföÅ\x1b[0m\t\x1b[32mbär\x1b[0m\t\x1b[36mfoobar\x1b[0m\n\
          \x1b[34mfoo\tbar\tfoobar\n\x1b[0m";
 
     iseq(
         tabw(),
+        &output[..],
+        "foo  bar  foobar\n\
+         \x1b[31mföÅ\x1b[0m  \x1b[32mbär\x1b[0m  \x1b[36mfoobar\x1b[0m\n\
+         \x1b[34mfoo  bar  foobar\n\x1b[0m",
+    )
+}
+
+// This tests that ANSI formatting is handled when explicitly opted into,
+// regardless of whether the ansi_formatting feature is enabled.
+#[test]
+fn ansi_formatting_by_config() {
+    let output = "foo\tbar\tfoobar\n\
+         \x1b[31mföÅ\x1b[0m\t\x1b[32mbär\x1b[0m\t\x1b[36mfoobar\x1b[0m\n\
+         \x1b[34mfoo\tbar\tfoobar\n\x1b[0m";
+
+    iseq(
+        tabw().ansi(true),
         &output[..],
         "foo  bar  foobar\n\
          \x1b[31mföÅ\x1b[0m  \x1b[32mbär\x1b[0m  \x1b[36mfoobar\x1b[0m\n\


### PR DESCRIPTION
This finally does the work to just remove the `regex` dependency entirely. The `regex` dependency was the primary reason that the ANSI handling was a crate feature. Namely, it permitted callers who didn't care about ANSI handling to avoid depending on the `regex` crate. But now that we drop the use of the `regex` crate entirely, we can just make ANSI handling a normal option of `TabWriter`. And that's what we do. We disable it by default.

This also deprecates the `ansi_formatting` feature. Now if one uses it, the only effect it has is to enable the `TabWriter::ansi` option by default. This avoids any breaking changes.

(I did consider replacing `regex` with `regex-lite`, which would have been an improvement. Especially since we were already disabling most of the regex crate's features anyway. But the regex was simple enough to just hand-code.)

We also bump to Rust 2021.