### PR TITLE
Optionally leave indent tabs unchanged

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -10,7 +10,7 @@ fn ordie<T, E: ToString>(r: Result<T, E>) -> T {
 }
 
 fn readable_str(s: &str) -> String {
-    s.replace(" ", "·")
+    s.replace(" ", "·").replace("\t", "<TAB>")
 }
 
 fn tabw() -> TabWriter<Vec<u8>> {
@@ -240,5 +240,26 @@ fn ansi_formatting_by_config() {
         "foo  bar  foobar\n\
          \x1b[31mföÅ\x1b[0m  \x1b[32mbär\x1b[0m  \x1b[36mfoobar\x1b[0m\n\
          \x1b[34mfoo  bar  foobar\n\x1b[0m",
+    )
+}
+
+#[test]
+fn tab_indent() {
+    iseq(
+        tabw().tab_indent(true).padding(1),
+        "
+type cell struct {
+\tsize\tint\t// cell size in bytes
+\twidth\tint\t// cell width in runes
+\thtab\tbool\t// true if the cell is terminated by an htab ('\\t')
+}
+",
+        "
+type cell struct {
+\tsize  int  // cell size in bytes
+\twidth int  // cell width in runes
+\thtab  bool // true if the cell is terminated by an htab ('\\t')
+}
+",
     )
 }


### PR DESCRIPTION
Indent tabs are the leading tabs used for indentation ("\<TAB\>" in the example below):
```
type cell struct {
<TAB>size  int  // cell size in bytes
<TAB>width int  // cell width in runes
<TAB>htab  bool // true if the cell is terminated by an htab ('\t')
}
```

Go leaves these unchanged in its `gofmt` tool instead of treating them as a tab column. This PR replicates the `IndentTabs` constant defined in https://pkg.go.dev/text/tabwriter#pkg-constants and its functionality.